### PR TITLE
refactor: remove ineffective memory cache mechanism from CLI framework

### DIFF
--- a/autogen_framework/memory_manager.py
+++ b/autogen_framework/memory_manager.py
@@ -45,10 +45,6 @@ class MemoryManager:
         
         # Set up logging
         self.logger = logging.getLogger(__name__)
-        
-        # Cache for loaded memory content
-        self._memory_cache: Optional[MemoryContent] = None
-        self._cache_timestamp: Optional[datetime] = None
     
     def _ensure_memory_directories(self) -> None:
         """Create memory directory structure if it doesn't exist."""
@@ -93,10 +89,6 @@ Memory files should be written in clear, structured markdown with:
         Returns:
             Dictionary containing all memory content organized by category and file
         """
-        # Check if we can use cached content
-        if self._is_cache_valid():
-            return self._memory_cache
-        
         memory_content = {}
         
         try:
@@ -117,10 +109,6 @@ Memory files should be written in clear, structured markdown with:
             )
             if root_memory:
                 memory_content["root"] = root_memory
-            
-            # Update cache
-            self._memory_cache = memory_content
-            self._cache_timestamp = datetime.now()
             
             self.logger.info(f"Loaded memory content from {len(memory_content)} categories")
             return memory_content
@@ -230,10 +218,6 @@ Memory files should be written in clear, structured markdown with:
             
             # Write the content
             file_path.write_text(formatted_content, encoding='utf-8')
-            
-            # Invalidate cache
-            self._memory_cache = None
-            self._cache_timestamp = None
             
             self.logger.info(f"Saved memory content: {key} in category {category}")
             return True
@@ -384,21 +368,6 @@ Memory files should be written in clear, structured markdown with:
                 stats["total_size_chars"] += cat_size
         
         return stats
-    
-    def _is_cache_valid(self) -> bool:
-        """Check if the memory cache is still valid."""
-        if not self._memory_cache or not self._cache_timestamp:
-            return False
-        
-        # Cache is valid for 5 minutes
-        cache_age = (datetime.now() - self._cache_timestamp).total_seconds()
-        return cache_age < 300
-    
-    def clear_cache(self) -> None:
-        """Clear the memory cache to force reload on next access."""
-        self._memory_cache = None
-        self._cache_timestamp = None
-        self.logger.info("Memory cache cleared")
     
     def export_memory(self, export_path: str, format: str = "json") -> bool:
         """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -125,7 +125,6 @@ def mock_memory_manager():
     })
     mock_manager.get_system_instructions = Mock(return_value="No memory content available.")
     mock_manager.export_memory = Mock(return_value=True)
-    mock_manager.clear_cache = Mock()
     
     return mock_manager
 

--- a/tests/unit/test_memory_manager.py
+++ b/tests/unit/test_memory_manager.py
@@ -210,22 +210,6 @@ class TestMemoryManager:
             assert "files" in cat_stats
             assert "size_chars" in cat_stats
     
-    def test_memory_caching(self, populated_memory_manager):
-        """Test memory caching functionality."""
-        # First load should populate cache
-        memory1 = populated_memory_manager.load_memory()
-        
-        # Second load should use cache (same object)
-        memory2 = populated_memory_manager.load_memory()
-        
-        assert memory1 == memory2
-        
-        # Clear cache and load again
-        populated_memory_manager.clear_cache()
-        memory3 = populated_memory_manager.load_memory()
-        
-        assert memory1 == memory3  # Content should be same, but freshly loaded
-    
     def test_export_memory_json(self, populated_memory_manager, temp_workspace):
         """Test exporting memory to JSON format."""
         export_path = Path(temp_workspace) / "exported_memory.json"


### PR DESCRIPTION
- Remove memory cache instance variables (_memory_cache, _cache_timestamp)
- Remove cache validation logic (_is_cache_valid method)
- Remove cache clearing functionality (clear_cache method)
- Remove cache invalidation in save_memory method
- Remove corresponding test for memory caching functionality
- Remove clear_cache mock from unit test fixtures

The memory cache was ineffective in CLI environment where each command runs in a new process, making the 5-minute cache timeout meaningless. This simplification reduces complexity while maintaining all core functionality for the CLI-based framework.